### PR TITLE
feat: add code tutorial highlights

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "shiki": "^4.0.1",
+        "shiki-magic-move": "^1.4.0",
         "svelte-sonner": "^1.0.8",
       },
       "devDependencies": {
@@ -152,6 +153,8 @@
 
     "@shikijs/langs": ["@shikijs/langs@4.0.1", "", { "dependencies": { "@shikijs/types": "4.0.1" } }, "sha512-v/mluaybWdnGJR4GqAR6zh8qAZohW9k+cGYT28Y7M8+jLbC0l4yG085O1A+WkseHTn+awd+P3UBymb2+MXFc8w=="],
 
+    "@shikijs/magic-move": ["@shikijs/magic-move@4.2.0", "", { "dependencies": { "diff-match-patch-es": "^1.0.1", "ohash": "^2.0.11" }, "peerDependencies": { "react": "^18.2.0 || ^19.0.0", "shiki": "^4.0.0", "solid-js": "^1.9.1", "svelte": "^5.0.0-0", "vue": "^3.4.0" }, "optionalPeers": ["react", "shiki", "solid-js", "svelte", "vue"] }, "sha512-KJBoKtpl04+ee6umjgt/qBveQPkCt+cMfaWJWbrRqqBtMCY8q0kufMPSjzJwLhNuSs2c0/D3BteOCOFAwg28rg=="],
+
     "@shikijs/primitive": ["@shikijs/primitive@4.0.1", "", { "dependencies": { "@shikijs/types": "4.0.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-ns0hHZc5eWZuvuIEJz2pTx3Qecz0aRVYumVQJ8JgWY2tq/dH8WxdcVM49Fc2NsHEILNIT6vfdW9MF26RANWiTA=="],
 
     "@shikijs/themes": ["@shikijs/themes@4.0.1", "", { "dependencies": { "@shikijs/types": "4.0.1" } }, "sha512-FW41C/D6j/yKQkzVdjrRPiJCtgeDaYRJFEyCKFCINuRJRj9WcmubhP4KQHPZ4+9eT87jruSrYPyoblNRyDFzvA=="],
@@ -267,6 +270,8 @@
     "devalue": ["devalue@5.6.3", "", {}, "sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "diff-match-patch-es": ["diff-match-patch-es@1.0.1", "", {}, "sha512-KhSofrZDERg/NE6Nd+TK53knp2qz0o2Ix8rhkXd3Chfm7Wlo58Eq/juNmkyS6bS+3xS26L3Pstz3BdY/q+e9UQ=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ=="],
 
@@ -444,6 +449,8 @@
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
     "oniguruma-parser": ["oniguruma-parser@0.12.1", "", {}, "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w=="],
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.4", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA=="],
@@ -489,6 +496,8 @@
     "set-cookie-parser": ["set-cookie-parser@3.0.1", "", {}, "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q=="],
 
     "shiki": ["shiki@4.0.1", "", { "dependencies": { "@shikijs/core": "4.0.1", "@shikijs/engine-javascript": "4.0.1", "@shikijs/engine-oniguruma": "4.0.1", "@shikijs/langs": "4.0.1", "@shikijs/themes": "4.0.1", "@shikijs/types": "4.0.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-EkAEhDTN5WhpoQFXFw79OHIrSAfHhlImeCdSyg4u4XvrpxKEmdo/9x/HWSowujAnUrFsGOwWiE58a6GVentMnQ=="],
+
+    "shiki-magic-move": ["shiki-magic-move@1.4.0", "", { "dependencies": { "@shikijs/magic-move": "^4.2.0" }, "peerDependencies": { "react": "^18.2.0 || ^19.0.0", "shiki": "^4.0.0", "solid-js": "^1.9.1", "svelte": "^5.0.0-0", "vue": "^3.4.0" }, "optionalPeers": ["react", "shiki", "solid-js", "svelte", "vue"] }, "sha512-DDEv7khyBMAQghQEfQ6Ab3KZxT5ub6tVNe8+NcvglWauKVV9jxiRYC055DoiFLgvs6Hd9+LuBndeaSPNOSxgSg=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"rehype-slug": "^6.0.0",
 		"remark-gfm": "^4.0.1",
 		"shiki": "^4.0.1",
+		"shiki-magic-move": "^1.4.0",
 		"svelte-sonner": "^1.0.8"
 	}
 }

--- a/src/content/markdown-pages/animation/code-tutorial-example.mdx
+++ b/src/content/markdown-pages/animation/code-tutorial-example.mdx
@@ -1,0 +1,33 @@
+---
+slug: "/posts/programming/code-tutorial-example"
+date: "2026-06-07"
+title: "CodeTutorial 컴포넌트 사용 예시"
+description: "MDX 문서 안에서 코드 변경 애니메이션을 탭과 스크롤 방식으로 보여주는 예시"
+tags: ["programming", "animation", "svelte", "mdx"]
+---
+
+이 문서는 `CodeTutorial` 컴포넌트를 MDX 안에서 어떻게 쓰는지 확인하기 위한 예시입니다.
+
+> 이 글은 프로그래밍 목록에 노출되는 예시 글입니다.
+
+# MDX에서 사용하는 방식
+
+현재 프로젝트의 `escape-mdsvex` 전처리기는 MDX 본문 안의 `{}`를 escape합니다. 그래서 MDX에서 복잡한 배열 prop을 직접 넘기기보다는, 예제 데이터를 Svelte 컴포넌트로 분리하고 MDX에서는 그 컴포넌트만 렌더링하는 방식을 권장합니다.
+
+```svelte
+<script>
+	import { CodeTutorialDemo } from '$lib/components/CodeTutorial';
+</script>
+
+<CodeTutorialDemo />
+```
+
+실제 예제 데이터와 `CodeTutorial` 사용 코드는 아래 파일에 들어 있습니다.
+
+```text
+src/lib/components/CodeTutorial/CodeTutorialDemo.svelte
+```
+
+# 실행 예시
+
+<CodeTutorialDemo />

--- a/src/lib/components/CodeTutorial/CodeTutorial.svelte
+++ b/src/lib/components/CodeTutorial/CodeTutorial.svelte
@@ -1,0 +1,408 @@
+<script module lang="ts">
+	import { createHighlighter } from 'shiki';
+
+	const highlighterPromise = createHighlighter({
+		themes: ['github-light', 'github-dark'],
+		langs: [
+			'javascript',
+			'typescript',
+			'html',
+			'css',
+			'json',
+			'bash',
+			'shell',
+			'markdown',
+			'yaml',
+			'jsx',
+			'tsx',
+			'svelte',
+			'python',
+			'go',
+			'rust',
+			'sql',
+			'diff',
+			'text'
+		]
+	});
+</script>
+
+<script lang="ts">
+	import { onMount, tick } from 'svelte';
+	import { ShikiMagicMove } from 'shiki-magic-move/svelte';
+	import 'shiki-magic-move/dist/style.css';
+
+	type TutorialMode = 'tabs' | 'scroll';
+
+	type LineHighlight = number | [number, number] | { start: number; end?: number };
+
+	export type CodeTutorialStep = {
+		title?: string;
+		description?: string;
+		code: string;
+		lang?: string;
+		filename?: string;
+		/** 1-based line numbers or ranges to emphasize for this step. */
+		highlightLines?: LineHighlight[];
+	};
+
+	interface Props {
+		steps: CodeTutorialStep[];
+		mode?: TutorialMode;
+		lang?: string;
+		theme?: 'github-light' | 'github-dark';
+		initialStep?: number;
+		stickyOffset?: number;
+		lineNumbers?: boolean;
+	}
+
+	let {
+		steps,
+		mode = 'tabs',
+		lang = 'typescript',
+		theme = 'github-light',
+		initialStep = 0,
+		stickyOffset = 128,
+		lineNumbers = true
+	}: Props = $props();
+
+	let activeStep = $state(0);
+	let initialStepApplied = $state(false);
+	let root: HTMLElement;
+
+	$effect(() => {
+		if (!initialStepApplied) {
+			activeStep = Math.min(Math.max(initialStep, 0), Math.max(steps.length - 1, 0));
+			initialStepApplied = true;
+		}
+
+		if (activeStep >= steps.length) activeStep = Math.max(steps.length - 1, 0);
+	});
+	let codePanel: HTMLElement;
+
+	const active = $derived(steps[activeStep] ?? steps[0]);
+	const activeCode = $derived(active?.code ?? '');
+	const activeLang = $derived(active?.lang ?? lang);
+	const activeHighlightLayers = $derived(formatHighlightLayers(active?.highlightLines));
+
+	function normalizeHighlightLines(highlightLines: LineHighlight[] = []) {
+		return highlightLines
+			.map((highlight) => {
+				if (typeof highlight === 'number') return { start: highlight, end: highlight };
+				if (Array.isArray(highlight)) return { start: highlight[0], end: highlight[1] };
+				return { start: highlight.start, end: highlight.end ?? highlight.start };
+			})
+			.map(({ start, end }) => ({ start: Math.max(1, start), end: Math.max(start, end) }))
+			.filter(({ start, end }) => Number.isFinite(start) && Number.isFinite(end));
+	}
+
+	function formatHighlightLayers(highlightLines: LineHighlight[] = []) {
+		const paddingTop = 1.8;
+		const lineHeight = 2.45;
+		const color = 'rgba(255, 209, 102, 0.24)';
+
+		return normalizeHighlightLines(highlightLines)
+			.map(({ start, end }) => {
+				const from = paddingTop + (start - 1) * lineHeight;
+				const to = paddingTop + end * lineHeight;
+				return `linear-gradient(to bottom, transparent ${from}rem, ${color} ${from}rem, ${color} ${to}rem, transparent ${to}rem)`;
+			})
+			.join(', ');
+	}
+
+	function selectStep(index: number) {
+		activeStep = index;
+	}
+
+	onMount(() => {
+		if (mode !== 'scroll') return;
+
+		let cleanup = () => {};
+		let cancelled = false;
+
+		async function setupScrollTrigger() {
+			await tick();
+			if (cancelled || !root) return;
+
+			const [{ default: gsap }, { ScrollTrigger }] = await Promise.all([
+				import('gsap'),
+				import('gsap/ScrollTrigger')
+			]);
+
+			if (cancelled) return;
+
+			gsap.registerPlugin(ScrollTrigger);
+
+			const triggers = Array.from(root.querySelectorAll<HTMLElement>('[data-code-step]')).map(
+				(el, index) =>
+					ScrollTrigger.create({
+						trigger: el,
+						start: 'top center',
+						end: 'bottom center',
+						onEnter: () => selectStep(index),
+						onEnterBack: () => selectStep(index)
+					})
+			);
+
+			cleanup = () => triggers.forEach((trigger) => trigger.kill());
+		}
+
+		setupScrollTrigger();
+
+		return () => {
+			cancelled = true;
+			cleanup();
+		};
+	});
+</script>
+
+<div bind:this={root} class="code-tutorial" class:scroll-mode={mode === 'scroll'}>
+	<section class="code-area" style={`--sticky-offset: ${stickyOffset}px`} bind:this={codePanel}>
+		<div class="code-meta">
+			<span>{active?.filename ?? active?.title ?? 'example'}</span>
+			<span>{activeLang}</span>
+		</div>
+
+		{#await highlighterPromise}
+			<pre class="fallback"><code>{activeCode}</code></pre>
+		{:then highlighter}
+			<div
+				class="code-frame"
+				class:has-highlights={activeHighlightLayers.length > 0}
+				style={`--code-highlight-layers: ${activeHighlightLayers || 'none'}`}
+			>
+				<ShikiMagicMove
+					code={activeCode}
+					lang={activeLang}
+					{theme}
+					{highlighter}
+					options={{
+						duration: 760,
+						easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+						stagger: 0.08,
+						delayMove: 0.12,
+						delayEnter: 0.45,
+						delayContainer: 0.2,
+						lineNumbers,
+						splitTokens: true,
+						enhanceMatching: true
+					}}
+				/>
+			</div>
+		{:catch error}
+			<pre class="fallback"><code>{activeCode}</code></pre>
+		{/await}
+	</section>
+
+	{#if mode === 'tabs'}
+		<div class="tabs" role="tablist" aria-label="Code tutorial steps">
+			{#each steps as step, index}
+				<button
+					type="button"
+					role="tab"
+					aria-selected={activeStep === index}
+					class:active={activeStep === index}
+					onclick={() => selectStep(index)}
+				>
+					<span>{index + 1}</span>
+					{step.title ?? `Step ${index + 1}`}
+				</button>
+			{/each}
+		</div>
+
+		{#if active?.description}
+			<p class="step-description">{active.description}</p>
+		{/if}
+	{:else}
+		<div class="steps">
+			{#each steps as step, index}
+				<article data-code-step class:active={activeStep === index}>
+					<p class="step-index">STEP {index + 1}</p>
+					<h3>{step.title ?? `Step ${index + 1}`}</h3>
+					{#if step.description}
+						<p>{step.description}</p>
+					{/if}
+				</article>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.code-tutorial {
+		margin: 3.2rem 0;
+		border: 1px solid rgba(64, 54, 46, 0.12);
+		border-radius: 1.8rem;
+		background: color-mix(in srgb, var(--color-cream) 82%, white);
+		box-shadow: 0 18px 50px rgba(64, 54, 46, 0.08);
+		overflow: clip;
+	}
+
+	.code-area {
+		background: #ffffff;
+		border-bottom: 1px solid rgba(64, 54, 46, 0.1);
+	}
+
+	.scroll-mode {
+		display: grid;
+		grid-template-columns: minmax(0, 1.1fr) minmax(24rem, 0.9fr);
+		gap: 0;
+		align-items: start;
+	}
+
+	.scroll-mode .code-area {
+		position: sticky;
+		top: var(--sticky-offset);
+		border-right: 1px solid rgba(64, 54, 46, 0.1);
+		border-bottom: 0;
+	}
+
+	.code-meta {
+		display: flex;
+		justify-content: space-between;
+		gap: 1.6rem;
+		padding: 1.2rem 1.6rem;
+		border-bottom: 1px solid rgba(64, 54, 46, 0.08);
+		color: var(--color-muted);
+		font-size: 1.3rem;
+		font-weight: 700;
+	}
+
+	.code-frame {
+		--code-highlight-layers: none;
+	}
+
+	:global(.shiki-magic-move-container) {
+		margin: 0 !important;
+		padding: 1.8rem !important;
+		background-color: #ffffff !important;
+		font-size: 1.4rem;
+		line-height: 1.75;
+		overflow-x: auto;
+	}
+
+	.code-frame.has-highlights :global(.shiki-magic-move-container) {
+		background-image: var(--code-highlight-layers) !important;
+		background-repeat: no-repeat;
+		transition: background-image 220ms ease;
+	}
+
+	:global(.shiki-magic-move-enter-from) {
+		transform: translateY(0.35em) scale(0.98);
+	}
+
+	:global(.shiki-magic-move-leave-to) {
+		transform: translateY(-0.25em) scale(0.98);
+	}
+
+	:global(.shiki-magic-move-move) {
+		will-change: transform;
+	}
+
+	.fallback {
+		padding: 1.8rem;
+		font-size: 1.4rem;
+		line-height: 1.75;
+		overflow-x: auto;
+	}
+
+	.tabs {
+		display: flex;
+		gap: 0.8rem;
+		padding: 1.4rem;
+		overflow-x: auto;
+	}
+
+	.tabs button {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.7rem;
+		border: 1px solid rgba(64, 54, 46, 0.12);
+		border-radius: 999px;
+		padding: 0.8rem 1.2rem;
+		background: white;
+		color: var(--color-basic);
+		font-size: 1.35rem;
+		font-weight: 700;
+		cursor: pointer;
+		white-space: nowrap;
+		transition: 160ms ease;
+	}
+
+	.tabs button span {
+		display: grid;
+		place-items: center;
+		width: 2rem;
+		height: 2rem;
+		border-radius: 50%;
+		background: var(--color-cream);
+		font-size: 1.15rem;
+	}
+
+	.tabs button:hover,
+	.tabs button.active {
+		border-color: var(--color-hl-light);
+		background: var(--color-hl-light);
+		color: white;
+		transform: translateY(-1px);
+	}
+
+	.step-description {
+		padding: 0 1.8rem 1.8rem;
+		color: var(--color-basic);
+		font-size: 1.55rem;
+		line-height: 1.8;
+	}
+
+	.steps {
+		padding: 1.6rem;
+	}
+
+	.steps article {
+		min-height: 42vh;
+		padding: 2rem;
+		border-left: 3px solid rgba(64, 54, 46, 0.14);
+		color: var(--color-muted);
+		transition: 180ms ease;
+	}
+
+	.steps article.active {
+		border-left-color: var(--color-hl-light);
+		color: var(--color-basic);
+		background: rgba(255, 255, 255, 0.64);
+	}
+
+	.step-index {
+		margin-bottom: 0.8rem;
+		color: var(--color-hl-light);
+		font-size: 1.2rem;
+		font-weight: 900;
+		letter-spacing: 0.08em;
+	}
+
+	.steps h3 {
+		margin-bottom: 0.8rem;
+		font-size: 2rem;
+	}
+
+	.steps p {
+		font-size: 1.55rem;
+		line-height: 1.85;
+	}
+
+	@media (max-width: 820px) {
+		.scroll-mode {
+			display: block;
+		}
+
+		.scroll-mode .code-area {
+			position: relative;
+			top: auto;
+			border-right: 0;
+			border-bottom: 1px solid rgba(64, 54, 46, 0.1);
+		}
+
+		.steps article {
+			min-height: auto;
+		}
+	}
+</style>

--- a/src/lib/components/CodeTutorial/CodeTutorialDemo.svelte
+++ b/src/lib/components/CodeTutorial/CodeTutorialDemo.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+	import CodeTutorial from './CodeTutorial.svelte';
+	import type { CodeTutorialStep } from './CodeTutorial.svelte';
+
+	const openScript = '<script>';
+	const closeScript = '</' + 'script>';
+
+	const tabSteps: CodeTutorialStep[] = [
+		{
+			title: '일반 변수',
+			description: '처음에는 단순한 변수로 count 값을 선언합니다.',
+			filename: 'counter.ts',
+			lang: 'ts',
+			highlightLines: [1],
+			code: ['const count = 0;', '', 'console.log(count);'].join('\n')
+		},
+		{
+			title: 'Svelte 상태',
+			description: 'Svelte 5의 $state rune으로 반응형 상태를 만듭니다.',
+			filename: 'Counter.svelte',
+			lang: 'svelte',
+			highlightLines: [2, 5],
+			code: [openScript, '\tlet count = $state(0);', closeScript, '', '<p>{count}</p>'].join('\n')
+		},
+		{
+			title: '클릭 이벤트',
+			description: '버튼을 누르면 count가 증가하도록 이벤트를 연결합니다.',
+			filename: 'Counter.svelte',
+			lang: 'svelte',
+			highlightLines: [[5, 7]],
+			code: [
+				openScript,
+				'\tlet count = $state(0);',
+				closeScript,
+				'',
+				'<button onclick={() => count++}>',
+				'\tcount: {count}',
+				'</button>'
+			].join('\n')
+		}
+	];
+
+	const reactSteps: CodeTutorialStep[] = [
+		{
+			title: '컴포넌트 분리',
+			description: 'React 컴포넌트 예시도 tsx/jsx 언어로 그대로 표시할 수 있습니다.',
+			filename: 'Counter.tsx',
+			lang: 'tsx',
+			highlightLines: [2],
+			code: `export function Counter() {
+	return <button>count: 0</button>;
+}`
+		},
+		{
+			title: '상태 추가',
+			description: 'useState를 추가하면 변경된 코드가 자연스럽게 애니메이션됩니다.',
+			filename: 'Counter.tsx',
+			lang: 'tsx',
+			highlightLines: [1, 4, 6],
+			code: `import { useState } from 'react';
+
+export function Counter() {
+	const [count, setCount] = useState(0);
+
+	return <button>count: {count}</button>;
+}`
+		},
+		{
+			title: '이벤트 연결',
+			description: '클릭 핸들러까지 추가한 최종 형태입니다.',
+			filename: 'Counter.tsx',
+			lang: 'tsx',
+			highlightLines: [{ start: 7, end: 9 }],
+			code: `import { useState } from 'react';
+
+export function Counter() {
+	const [count, setCount] = useState(0);
+
+	return (
+		<button onClick={() => setCount(count + 1)}>
+			count: {count}
+		</button>
+	);
+}`
+		}
+	];
+
+	const scrollSteps: CodeTutorialStep[] = [
+		{
+			title: 'HTML 구조 작성',
+			description: '먼저 카드의 의미 있는 마크업을 작성합니다.',
+			filename: 'Card.svelte',
+			lang: 'svelte',
+			highlightLines: [[1, 4]],
+			code: [
+				'<article class="card">',
+				'\t<h2>오늘의 메모</h2>',
+				'\t<p>MDX 안에서 움직이는 코드 예제를 만들 수 있습니다.</p>',
+				'</article>'
+			].join('\n')
+		},
+		{
+			title: '기본 스타일 추가',
+			description: '카드가 글 본문 안에서 자연스럽게 보이도록 여백과 테두리를 추가합니다.',
+			filename: 'Card.svelte',
+			lang: 'svelte',
+			highlightLines: [[6, 12]],
+			code: [
+				'<article class="card">',
+				'\t<h2>오늘의 메모</h2>',
+				'\t<p>MDX 안에서 움직이는 코드 예제를 만들 수 있습니다.</p>',
+				'</article>',
+				'',
+				'<style>',
+				'\t.card {',
+				'\t\tpadding: 1.6rem;',
+				'\t\tborder: 1px solid #e5e7eb;',
+				'\t\tborder-radius: 1rem;',
+				'\t}',
+				'</style>'
+			].join('\n')
+		},
+		{
+			title: '상호작용 추가',
+			description: '상태를 추가해서 버튼 클릭으로 내용을 바꿉니다. 스크롤 위치에 따라 왼쪽 코드가 변경됩니다.',
+			filename: 'Card.svelte',
+			lang: 'svelte',
+			highlightLines: [2, [8, 10]],
+			code: [
+				openScript,
+				'\tlet liked = $state(false);',
+				closeScript,
+				'',
+				'<article class="card">',
+				'\t<h2>오늘의 메모</h2>',
+				'\t<p>MDX 안에서 움직이는 코드 예제를 만들 수 있습니다.</p>',
+				'\t<button onclick={() => liked = !liked}>',
+				"\t\t{liked ? '좋아요 취소' : '좋아요'}",
+				'\t</button>',
+				'</article>',
+				'',
+				'<style>',
+				'\t.card {',
+				'\t\tpadding: 1.6rem;',
+				'\t\tborder: 1px solid #e5e7eb;',
+				'\t\tborder-radius: 1rem;',
+				'\t}',
+				'</style>'
+			].join('\n')
+		}
+	];
+</script>
+
+<h2>탭 방식 데모</h2>
+<CodeTutorial steps={tabSteps} mode="tabs" />
+
+<h2>React 예시</h2>
+<CodeTutorial steps={reactSteps} mode="tabs" lang="tsx" />
+
+<h2>스크롤 방식 데모</h2>
+<CodeTutorial steps={scrollSteps} mode="scroll" stickyOffset={128} />

--- a/src/lib/components/CodeTutorial/index.ts
+++ b/src/lib/components/CodeTutorial/index.ts
@@ -1,0 +1,3 @@
+export { default as CodeTutorial } from './CodeTutorial.svelte';
+export { default as CodeTutorialDemo } from './CodeTutorialDemo.svelte';
+export type { CodeTutorialStep } from './CodeTutorial.svelte';

--- a/src/lib/escape-mdsvex.js
+++ b/src/lib/escape-mdsvex.js
@@ -5,13 +5,15 @@
  */
 
 const COMPONENT_LINE_RE =
-	/^\s*<\/?(Quotation|Canvas|ImageComment|Tabs|script|div|iframe|img|br|a\s|a>)/;
+	/^\s*<\/?(Quotation|Canvas|ImageComment|Tabs|CodeTutorial|CodeTutorialDemo|script|div|iframe|img|br|a\s|a>)/;
 
 const COMPONENT_IMPORTS = {
 	Quotation: "import Quotation from '$lib/components/Quotation/Quotation.svelte';",
 	Canvas: "import Canvas from '$lib/components/Canvas/Canvas.svelte';",
 	ImageComment: "import ImageComment from '$lib/components/ImageComment/ImageComment.svelte';",
-	Tabs: "import Tabs from '$lib/components/Tabs/Tabs.svelte';"
+	Tabs: "import Tabs from '$lib/components/Tabs/Tabs.svelte';",
+	CodeTutorial: "import { CodeTutorial } from '$lib/components/CodeTutorial';",
+	CodeTutorialDemo: "import { CodeTutorialDemo } from '$lib/components/CodeTutorial';"
 };
 
 export function escapeMdsvex() {


### PR DESCRIPTION
## Summary
- Add CodeTutorial component with Shiki Magic Move code transition animation
- Add per-step line highlighting via highlightLines
- Add CodeTutorial demo/example page and MDX imports

## Validation
- Ran `npm run check` — existing diagnostics remain in `src/lib/escape-mdsvex.js`, `src/lib/components/Post/PostContent.svelte`, and Header accessibility warnings.